### PR TITLE
Remove zope.interface from list of packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ rjsmin==1.0.12
 simplejson==3.8.2
 Twisted==16.2.0
 uWSGI==2.0.13.1
-zope.interface==4.2.0


### PR DESCRIPTION
Doesn't actually need a C-compiler to build so containers can build it themselves.
