### PR TITLE
uWSGI build on Alpine/cPython 3.5 is flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,12 @@ env:
     - DOCKER_IMAGE=pypy:2-5.3.1                            PYPI_REPO=jessie   # Debian/PyPy2
     - DOCKER_IMAGE=praekeltfoundation/alpine-python:2.7.12 PYPI_REPO=alpine-3 # Alpine/cPython 2.7
     - DOCKER_IMAGE=praekeltfoundation/alpine-python:3.5.2  PYPI_REPO=alpine-3 # Alpine/cPython 3.5
-    allow_failures:
-      # FIXME: uWSGI fails to build sometimes specifically on this platform
-      # https://github.com/unbit/uwsgi/issues/1318
-      # Ignore failures for now since the platform is rarely used
-      - env: DOCKER_IMAGE=praekeltfoundation/alpine-python:3.5.2  PYPI_REPO=alpine-3
+matrix:
+  allow_failures:
+    # FIXME: uWSGI fails to build sometimes specifically on this platform
+    # https://github.com/unbit/uwsgi/issues/1318
+    # Ignore failures for now since the platform is rarely used
+    - env: DOCKER_IMAGE=praekeltfoundation/alpine-python:3.5.2  PYPI_REPO=alpine-3
 
 install:
   - docker pull $DOCKER_IMAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ env:
     - DOCKER_IMAGE=pypy:2-5.3.1                            PYPI_REPO=jessie   # Debian/PyPy2
     - DOCKER_IMAGE=praekeltfoundation/alpine-python:2.7.12 PYPI_REPO=alpine-3 # Alpine/cPython 2.7
     - DOCKER_IMAGE=praekeltfoundation/alpine-python:3.5.2  PYPI_REPO=alpine-3 # Alpine/cPython 3.5
+    allow_failures:
+      # FIXME: uWSGI fails to build sometimes specifically on this platform
+      # https://github.com/unbit/uwsgi/issues/1318
+      # Ignore failures for now since the platform is rarely used
+      - env: DOCKER_IMAGE=praekeltfoundation/alpine-python:3.5.2  PYPI_REPO=alpine-3
 
 install:
   - docker pull $DOCKER_IMAGE


### PR DESCRIPTION
When it crashes it has the message:
`gcc: error trying to exec 'cc1': execvp: No such file or directory`

But it doesn't always crash...
