### PR TITLE
Add Debian Stretch builds

### DIFF
--- a/.pypirc
+++ b/.pypirc
@@ -12,3 +12,6 @@ repository: https://alpine-3-6.wheelhouse.praekelt.org
 
 [jessie]
 repository: https://jessie.wheelhouse.praekelt.org
+
+[stretch]
+repository: https://stretch.wheelhouse.praekelt.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,12 @@ matrix:
       - PYPI_REPO=stretch
     # Debian Jessie/PyPy2
     - env:
-      - DOCKER_IMAGE=pypy:2-5.8.0
+      - DOCKER_IMAGE=pypy:2-5.9.0
       - EXTRA_REQUIREMENT=requirements-debian.txt
       - PYPI_REPO=jessie
     # Debian Jessie/PyPy3
     - env:
-      - DOCKER_IMAGE=pypy:3-5.8.0
+      - DOCKER_IMAGE=pypy:3-5.9.0
       - EXTRA_REQUIREMENT=requirements-debian.txt
       - PYPI_REPO=jessie
     # Alpine 3.4/cPython 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,22 +14,32 @@ env:
     - secure: "mkYj3fOKFymdaO2x29gFbvId1wwo3HV3+8cCCgneZXwvlRThfGjIMFSYGJAcLXsX5cudV0jvgbICGP7vZgmbEBiTFJreimO+19TLVzzgx54lR1dNkYQbVWxlUZqlI+uSW0KV6L1jj8UAIEEMOHe8zduhKqom7BkLhoAJNPIzaBxoB+unvzwqDYokzqroSLBljeqfYnRcLTdt7kM2UHrgA3Pnl5CyRSWBCUsWPbC8JE2IrXMkCxo26cDbNOb7eFIP7OP3qhH/UH5igp5X/2kHwc3xRTLAbycsd511vCHzgGfQreFcmbAljXzX0oAiuN/EJgiNhvqGTT7Kev9gB0fr0ZlaZEMhSA2fabvYgQpd0cg765KsDnCTFzTY5FZ+rRNJ5FWlHtuIGXnKPQtnq6kth7nXqmVu25FGEJnSwJgq7uugWWCr5sUFN1OHjINDvrabKbJGgLp+R93hwrnX+TsJowvB389fSEbVYq+vg/9UA9GyWV8d0YJL7ljnUX81yB+jsm2Lk+ndo8wSnqdE127nE8wYB1stdowmoHWvN1GgltG5A2KC1oDlv/7Ga1RdTQW1lMjA9z19FY4EtpnoSDgGZbK8Pztq+F/cTCO1JyzguNagrbzec6R2kxHJKn3A1ZfvnHQCgmiD113l5xnw9K8QHqhGZcScxIhsNl6CkG6mBp8="
 matrix:
   include:
-    # Debian/cPython 2.7
+    # Debian Jessie/cPython 2.7
     - env:
-      - DOCKER_IMAGE=python:2.7.13
+      - DOCKER_IMAGE=python:2.7.13-jessie
       - EXTRA_REQUIREMENT=requirements-debian.txt
       - PYPI_REPO=jessie
-    # Debian/cPython 3.6
+    # Debian Jessie/cPython 3.6
     - env:
-      - DOCKER_IMAGE=python:3.6.2
+      - DOCKER_IMAGE=python:3.6.2-jessie
       - EXTRA_REQUIREMENT=requirements-debian.txt
       - PYPI_REPO=jessie
-    # Debian/PyPy2
+    # Debian Stretch/cPython 2.7
+    - env:
+      - DOCKER_IMAGE=python:2.7.13-stretch
+      - EXTRA_REQUIREMENT=requirements-debian.txt
+      - PYPI_REPO=stretch
+    # Debian Stretch/cPython 3.6
+    - env:
+      - DOCKER_IMAGE=python:3.6.2-stretch
+      - EXTRA_REQUIREMENT=requirements-debian.txt
+      - PYPI_REPO=stretch
+    # Debian Jessie/PyPy2
     - env:
       - DOCKER_IMAGE=pypy:2-5.8.0
       - EXTRA_REQUIREMENT=requirements-debian.txt
       - PYPI_REPO=jessie
-    # Debian/PyPy3
+    # Debian Jessie/PyPy3
     - env:
       - DOCKER_IMAGE=pypy:3-5.8.0
       - EXTRA_REQUIREMENT=requirements-debian.txt


### PR DESCRIPTION
This is still a while out as there are no `-slim`-flavoured Stretch-based images for us to use yet.

We'd also need a Stretch pypiserver instance.