### PR TITLE
Some maintenance things

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,6 @@ DOCKER_IMAGE="python:2"
 REQUIREMENTS=()
 WHEEL_DIR="$(pwd)/wheelhouse"
 NO_DEPS="--no-deps"
-NO_BINARIES="--no-binary :all:"
 
 while [[ $# > 0 ]]; do
     key="$1"; shift
@@ -22,9 +21,6 @@ while [[ $# > 0 ]]; do
             ;;
         --deps)
             NO_DEPS=""
-            ;;
-        --binaries)
-            NO_BINARIES=""
             ;;
         *)
             # Unknown option
@@ -50,4 +46,4 @@ docker run --rm \
   "${REQUIREMENT_VOLUMES[@]}" \
   -v "$WHEEL_DIR":/wheelhouse \
   $DOCKER_IMAGE \
-  pip wheel "${REQUIREMENT_OPTS[@]}" -w /wheelhouse -f /wheelhouse $NO_DEPS $NO_BINARIES
+  pip wheel "${REQUIREMENT_OPTS[@]}" -w /wheelhouse -f /wheelhouse $NO_DEPS

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ DOCKER_IMAGE="python:2"
 REQUIREMENTS=()
 WHEEL_DIR="$(pwd)/wheelhouse"
 NO_DEPS="--no-deps"
+NO_BINARIES="--no-binary :all:"
 
 while [[ $# > 0 ]]; do
     key="$1"; shift
@@ -21,6 +22,9 @@ while [[ $# > 0 ]]; do
             ;;
         --deps)
             NO_DEPS=""
+            ;;
+        --binaries)
+            NO_BINARIES=""
             ;;
         *)
             # Unknown option
@@ -46,4 +50,4 @@ docker run --rm \
   "${REQUIREMENT_VOLUMES[@]}" \
   -v "$WHEEL_DIR":/wheelhouse \
   $DOCKER_IMAGE \
-  pip wheel "${REQUIREMENT_OPTS[@]}" -w /wheelhouse -f /wheelhouse $NO_DEPS
+  pip wheel "${REQUIREMENT_OPTS[@]}" -w /wheelhouse -f /wheelhouse $NO_DEPS $NO_BINARIES

--- a/requirements-alpine.txt
+++ b/requirements-alpine.txt
@@ -4,5 +4,4 @@ cffi==1.11.4
 cryptography==2.1.4
 lxml==4.1.1
 Pillow==5.0.0
-psycopg2==2.7.4
 numpy==1.14.0

--- a/requirements-debian.txt
+++ b/requirements-debian.txt
@@ -1,5 +1,4 @@
 # These have pre-compiled manylinux packages on CPython but not on PyPy
 cryptography==2.1.4; platform_python_implementation!='CPython'
 Pillow==5.0.0; platform_python_implementation!='CPython'
-# pyscopg2 is not compatible with PyPy
 lxml==4.1.1; platform_python_implementation!='CPython'

--- a/requirements-debian.txt
+++ b/requirements-debian.txt
@@ -1,5 +1,4 @@
 # These have pre-compiled manylinux packages on CPython but not on PyPy
-cffi==1.11.4; platform_python_implementation!='CPython'
 cryptography==2.1.4; platform_python_implementation!='CPython'
 Pillow==5.0.0; platform_python_implementation!='CPython'
 # pyscopg2 is not compatible with PyPy

--- a/requirements-debian.txt
+++ b/requirements-debian.txt
@@ -1,3 +1,8 @@
+# FIXME: uWSGI has trouble building under Alpine Linux. The difference between
+# Debian and Alpine cannot be determined using environment markers.
+# https://github.com/unbit/uwsgi/issues/1318
+uWSGI==2.0.16
+
 # These have pre-compiled manylinux packages on CPython but not on PyPy
 cryptography==2.1.4; platform_python_implementation!='CPython'
 Pillow==5.0.0; platform_python_implementation!='CPython'

--- a/requirements-debian.txt
+++ b/requirements-debian.txt
@@ -1,8 +1,3 @@
-# FIXME: uWSGI has trouble building under Alpine Linux. The difference between
-# Debian and Alpine cannot be determined using environment markers.
-# https://github.com/unbit/uwsgi/issues/1318
-uWSGI==2.0.16
-
 # These have pre-compiled manylinux packages on CPython but not on PyPy
 cffi==1.11.4; platform_python_implementation!='CPython'
 cryptography==2.1.4; platform_python_implementation!='CPython'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ subprocess32==3.2.7; python_version<'3'
 thriftpy==0.3.9
 Twisted==17.9.0
 ujson==1.35; platform_python_implementation=='CPython'
-uWSGI==2.0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ subprocess32==3.2.7; python_version<'3'
 thriftpy==0.3.9
 Twisted==17.9.0
 ujson==1.35; platform_python_implementation=='CPython'
+uWSGI==2.0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cairocffi==0.8.0
 hiredis==0.2.0
 mysqlclient==1.3.12
+psycopg2==2.7.4; platform_python_implementation=='CPython'
 psycopg2cffi==2.7.7
 pycrypto==2.6.1
 python_axolotl_curve25519==0.1


### PR DESCRIPTION
* ~~Try build uWSGI on Alpine again~~
* Don't build cffi for PyPy, should use bundled version
* Do build psycopg2 binaries for all supported platforms (http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/)